### PR TITLE
18 decimal places for ETH and Mochi

### DIFF
--- a/src/components/SwapWrapper.tsx
+++ b/src/components/SwapWrapper.tsx
@@ -19,7 +19,7 @@ export default function SwapComponents() {
   const ETHToken: Token = {
       address: "",
       chainId: 8453,
-      decimals: 10,
+      decimals: 18,
       name: "Ethereum",
       symbol: "ETH",
       image: "https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
@@ -28,7 +28,7 @@ export default function SwapComponents() {
   const MochiToken: Token = {
       address: "0xf6e932ca12afa26665dc4dde7e27be02a7c02e50",
       chainId: 8453,
-      decimals: 6,
+      decimals: 18,
       name: "Mochi",
       symbol: "MOCHI",
       image: "https://s2.coinmarketcap.com/static/img/coins/64x64/28478.png"


### PR DESCRIPTION
**What changed? Why?**
use 18 decimal places for ETH and Mochi to get correct swap data

**Notes to reviewers**

**How has it been tested?**
Tested on this fork of the repo manually: https://mochi-swap.vercel.app/
